### PR TITLE
Fix git-bash finding in Windows not working properly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,6 +172,7 @@ dependencies = [
  "normpath",
  "palette",
  "regex",
+ "same-file",
  "serde",
  "serde_json",
  "serde_path_to_error",
@@ -447,6 +448,15 @@ name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "serde"
@@ -769,6 +779,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
+dependencies = [
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ indexmap = { version = "2.2.6", default-features = false }
 normpath = { version = "1.2.0", default-features = false }
 palette = { version = "0.7.6", default-features = false }
 regex = { version = "1.10.5", default-features = false }
+same-file = { version = "1.0.6", default-features = false }
 serde = { version = "1.0.203", default-features = false }
 serde_json = { version = "1.0.118", default-features = false }
 serde_path_to_error = { version = "0.1.16", default-features = false }

--- a/crates/hyfetch/Cargo.toml
+++ b/crates/hyfetch/Cargo.toml
@@ -18,6 +18,7 @@ deranged = { workspace = true, features = ["serde", "std"] }
 directories = { workspace = true, features = [] }
 indexmap = { workspace = true, features = ["serde", "std"] }
 palette = { workspace = true, features = ["std"] }
+same-file = { workspace = true, features = [] }
 serde = { workspace = true, features = ["derive", "std"] }
 serde_json = { workspace = true, features = ["std"] }
 serde_path_to_error = { workspace = true, features = [] }

--- a/crates/hyfetch/src/bin/hyfetch.rs
+++ b/crates/hyfetch/src/bin/hyfetch.rs
@@ -41,7 +41,7 @@ _/\_\_   _/_/\_
 fn main() -> Result<()> {
     #[cfg(windows)]
     if let Err(err) = enable_ansi_support::enable_ansi_support() {
-        debug!(err, "could not enable ANSI escape code support");
+        debug!(%err, "could not enable ANSI escape code support");
     }
 
     let options = options().run();


### PR DESCRIPTION
<!-- Thank you so much for contributing! ❤️ -->

### Description
Fixed an issue where git-bash executable path finding in Windows not working properly, due to Windows path case-sensitivity issue.

### Relevant Links
https://doc.rust-lang.org/std/path/index.html#case-sensitivity

### Screenshots
None

### Additional context
None