### PR TITLE
Fix escaped backslashes in output ascii art by unescaping them

### DIFF
--- a/crates/hyfetch/build.rs
+++ b/crates/hyfetch/build.rs
@@ -226,9 +226,13 @@ where
             .next()
             .and_then(|pattern| pattern.trim().strip_suffix(')'))?;
 
+        // Unescape backslashes here because backslashes are escaped in neofetch
+        // for printf
+        let art = art.replace(r"\\", r"\");
+
         Some(AsciiDistro {
             pattern: pattern.to_owned(),
-            art: art.to_owned(),
+            art,
         })
     }
     blocks


### PR DESCRIPTION
<!-- Thank you so much for contributing! ❤️ -->

### Description
When the ascii art in `neofetch` contains backslashes (`\`), they are escaped as `\\` because it is eventually passed as an argument to `printf '%b\n'`. If this is not accounted for in `hyfetch`, the output ascii art will be visibly broken.

In both the Python and Rust versions, the ascii art codegen outputs raw strings, so the backslashes are not unescaped by the compiler/interpreter.

The Python implementation handles this by unescaping the backslashes before the ascii art is output in the codegen, as well as unescaping when the output when it is grabbed at a runtime when we fallback to a call of `neofetch` for a distro unsupported by the codegen. The fallback is a rare code path.

This Rust rewrite currently unescapes the backslashes from the runtime neofetch output, but is missing the step to do that in the codegen. That means the usual code path does not properly output correct ascii art for any distro with backslashes in its art. Check out `Bedrock` as an example distro that is broken.

This PR fixes that omission.

### Relevant Links
Python - [codegen unescape](https://github.com/hykilpikonna/hyfetch/blob/2a01c50aa6c8fc0cebfac5d8b982811b53802800/tools/list_distros.py#L147), [runtime fallback unescape](https://github.com/hykilpikonna/hyfetch/blob/2a01c50aa6c8fc0cebfac5d8b982811b53802800/hyfetch/neofetch_util.py#L292)
Rust - [runtime fallback unescape](https://github.com/rust-malaysia/hyfetch/blob/de43bf74a9b346e76540b4e8a9557753abcc5b41/crates/hyfetch/src/neofetch_util.rs#L484)

### Screenshots
Outputs of: `cargo run -- --distro Bedrock`

Before: 
![Screenshot_20240717_141948](https://github.com/user-attachments/assets/fee5adb2-0da1-41c6-8c14-2a2e06b69bbb)

After:
![Screenshot_20240717_141930](https://github.com/user-attachments/assets/c429e348-664b-4c40-b407-78dfda1e53a4)

### Additional context
None
