### PR TITLE
Fix the displaying of color arrangment labels in the interactive config

### DIFF
--- a/crates/hyfetch/src/bin/hyfetch.rs
+++ b/crates/hyfetch/src/bin/hyfetch.rs
@@ -783,7 +783,7 @@ fn create_config(
         let ascii_per_row: u8 = ascii_per_row
             .try_into()
             .expect("`ascii_per_row` should fit in `u8`");
-        let ascii_rows = cmp::max(1, (term_h - 8) / u16::from(asc_lines));
+        let ascii_rows = cmp::max(1, (term_h - 8) / (u16::from(asc_lines) + 2));
         let ascii_rows: u8 = ascii_rows
             .try_into()
             .expect("`ascii_rows` should fit in `u8`");
@@ -880,10 +880,11 @@ fn create_config(
                 .split('\n')
                 .map(ToOwned::to_owned)
                 .collect();
-            v.push(format!(
-                "{k:^asc_width$}",
-                asc_width = usize::from(asc_width)
-            ));
+            v.extend([
+                String::new(),
+                format!("{k:^asc_width$}", asc_width = usize::from(asc_width)),
+                String::new(),
+            ]);
             v
         });
 
@@ -891,7 +892,7 @@ fn create_config(
             let row: Vec<Vec<String>> = row.into_iter().collect();
 
             // Print by row
-            for i in 0..usize::from(asc_lines) + 1 {
+            for i in 0..usize::from(asc_lines) + 3 {
                 let mut line = String::new();
                 for lines in &row {
                     line.push_str(&lines[i]);

--- a/crates/hyfetch/src/utils.rs
+++ b/crates/hyfetch/src/utils.rs
@@ -11,6 +11,50 @@ use directories::ProjectDirs;
 use normpath::PathExt as _;
 use tracing::debug;
 
+pub trait JoinWithNewline {
+    fn join_with_newline(self) -> String;
+}
+
+pub trait JoinResultsWithNewline {
+    fn join_results_with_newline(self) -> Result<String>;
+}
+
+impl<I, S> JoinWithNewline for I
+where
+    S: AsRef<str>,
+    I: Iterator<Item = S>,
+{
+    fn join_with_newline(mut self) -> String {
+        let mut result = String::new();
+        if let Some(first) = self.next() {
+            result.push_str(first.as_ref());
+            for item in self {
+                result.push('\n');
+                result.push_str(item.as_ref());
+            }
+        }
+        result
+    }
+}
+
+impl<I, S> JoinResultsWithNewline for I
+where
+    S: AsRef<str>,
+    I: Iterator<Item = Result<S>>,
+{
+    fn join_results_with_newline(mut self) -> Result<String> {
+        let mut result = String::new();
+        if let Some(first) = self.next() {
+            result.push_str(first?.as_ref());
+            for item in self {
+                result.push('\n');
+                result.push_str(item?.as_ref());
+            }
+        }
+        Ok(result)
+    }
+}
+
 pub fn get_cache_path() -> Result<PathBuf> {
     let path = ProjectDirs::from("", "", "hyfetch")
         .context("failed to get base dirs")?


### PR DESCRIPTION
The main cause of the issue was how the various functions/blocks that modify the ascii art often end up adding a trailing newline, resulting in the recolored ascii having more lines than expected. Additionally, to match the python version for how the label is padded (1 blank line before the label, 2 blank lines afterward before the next row), minor changes are made to pad blank lines around the label.

Ensuring there is no trailing newline added is kind of tricky to implement in a way that does not fiddle with indices or otherwise is not noisy and does not repeat code. See [this StackOverflow question](https://stackoverflow.com/questions/26644486/in-rust-what-is-the-best-way-to-print-something-between-each-value-in-a-contain). I ended up with a decent solution that uses a trait to add a new method on iterators of Strings that will join them with newlines. That also requires generating a String per line for them to be joined, which adds allocations, but should not be a real performance concern.

Note: If you compare the fixed Rust and original Python screenshots, you will notice a difference in horizontal stripe coloring (different counts of some colors). This is due to how in the original Python code, the ascii art has a leading and trailing newline. That most definitely should be considered a bug in the Python version, because the logo ends up with the first and last stripe colors having less _visible_ lines, and a configured `hyfetch` output has the logo vertically padded with a blank line at the top which `neofetch` does not have. This difference why in this PR there is padding added around the labels to get the desired spacing, but there are no extra lines of padding added around the labels in the Python version.

### Relevant Links
[Comment reporting the issue](https://github.com/hykilpikonna/hyfetch/pull/317#issuecomment-2229874621)

### Screenshots
`cargo run -- -c --distro Arya`
Before (partially highlighted):
![rust-arya-before-highlighted](https://github.com/user-attachments/assets/78c96785-d045-4240-a5a7-502902f984d3)

After:
![rust-arya-after](https://github.com/user-attachments/assets/38a46580-6816-4b00-90e0-6b3db1fac133)

Python implementation reference:
`hyfetch -c --distro Arya`
![python-arya](https://github.com/user-attachments/assets/4d1107d1-0230-43e9-a903-e3dff7bc5787)

### Additional context
None