### PR TITLE
Normalize newlines for user provided ascii file

### DIFF
--- a/crates/hyfetch/src/bin/hyfetch.rs
+++ b/crates/hyfetch/src/bin/hyfetch.rs
@@ -139,7 +139,9 @@ fn main() -> Result<()> {
     let (asc, fore_back) = if let Some(path) = options.ascii_file {
         (
             fs::read_to_string(&path)
-                .with_context(|| format!("failed to read ascii from {path:?}"))?,
+                .with_context(|| format!("failed to read ascii from {path:?}"))?
+                .lines()
+                .join("\n"),
             None,
         )
     } else {


### PR DESCRIPTION
When an a user supplies ascii art in a file with `--ascii-file`, there are 2 issues they can have:

1. The file likely has a newline at the end, which most text editors ensure is there. However, we recolor text on lines based from `art.split('\n')`, which means that we have a blank line at the end. This results in an unbalanced distribution of color stripes since the blank line will be colored, but no color is shown without visible characters. If the number of lines in the ascii art is close to the number of colors, this can result in the final color stripe only coloring the last line, meaning it is not visible to the user. See hykilpikonna/hyfetch/issues/330 where the final blue color stripe is missing.
2. If the user created the ascii art file with Windows newlines `\r\n` (hyfetch runs on Windows) instead of Unix newlines `\n`, then the `art.split('\n')` leaves the `\r` in the line, resulting in incorrect ascii art width calculations and maybe more issues.

The easy way to deal with newlines in files is to use a lines iterator, not splitting on `\n`. A lines iterator handles the differing newline conventions, and the final newline properly as well. And the usually also strips out the newline characters. Thus, this fix gets an iterator over the lines, and then joins the lines with `\n`.

<!-- Thank you so much for contributing! ❤️ -->